### PR TITLE
Remove static variable from header

### DIFF
--- a/include/perfmon/thread_specific_counters.h
+++ b/include/perfmon/thread_specific_counters.h
@@ -22,15 +22,16 @@ struct TssCounters {
     TssCounter* counters;
 };
 
-TssCounters CreateTssCounters();
+extern RERFMON_THREAD_SPECIFIC TssCounters global_tss_counters;
+
+void ExpandTssCounters();
 
 inline void UpdateTssCounter(size_t counter_index, uint_fast64_t ticks)
 {
-    static PERFMON_THREAD_SPECIFIC TssCounters tss_counters;
-    if (tss_counters.size <= counter_index) {
-        tss_counters = CreateTssCounters();
+    if (global_tss_counters.size <= counter_index) {
+        ExpandTssCounters();
     }
-    auto& counter = tss_counters.counters[counter_index];
+    auto& counter = global_tss_counters.counters[counter_index];
     counter.calls += 1;
     counter.ticks += ticks;
 }

--- a/thread_specific_counters.cpp
+++ b/thread_specific_counters.cpp
@@ -107,10 +107,13 @@ TssCountersHolder& TssCountersHolder::GetInstance()
 } // namespace
 
 
-TssCounters CreateTssCounters()
+extern RERFMON_THREAD_SPECIFIC TssCounters global_tss_counters = {0, nullptr};
+
+
+void ExpandTssCounters()
 {
     const auto guard = GlobalLockGuard();
-    return TssCountersHolder::GetInstance().UnsafeExpand();
+    global_tss_counters = TssCountersHolder::GetInstance().UnsafeExpand();
 }
 
 void UnsafeFlushTssCounters()


### PR DESCRIPTION
This helps to avoid static variable duplicates (and following memory corruption) in case of multiple shared libraries using perfmon.
